### PR TITLE
scene-fix-incompatible-blend-operation

### DIFF
--- a/basics/prefabs/lantern_road.rca
+++ b/basics/prefabs/lantern_road.rca
@@ -293,7 +293,7 @@
                     "blendFactorSrcAlpha": 1,
                     "blendFactorSrcColor": 2,
                     "blendOperationAlpha": 0,
-                    "blendOperationColor": 1,
+                    "blendOperationColor": 0,
                     "cullmode": 2,
                     "depthFunction": 4,
                     "depthwrite": true


### PR DESCRIPTION
Fix incompatible color and alpha blend operation flags in Lantern material in lantern_road example project.

The incompatibility leads to a scene validation error which prevents correct export.