### PR TITLE
Add test build job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,7 @@ jobs:
     - name: Create archive
       shell: bash
       run: |
+        set -e
         python3 .github/package.py ${{runner.workspace}}/tutorials
 
     - name: Publish release

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: MPL-2.0
+#
+# This file is part of Ramses Composer
+# (see https://github.com/bmwcarit/ramses-composer-docs).
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+# If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+name: Test
+
+# Only pushes and PRs against the master branch are built
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        lfs: 'true'
+
+    - name: Install pip packages
+      shell: bash
+      run: |
+        set -e
+        python3 -m pip install -r doc/requirements.txt
+
+    - name: Test that archive can be created
+      shell: bash
+      run: |
+        set -e
+        python3 .github/package.py ${{runner.workspace}}/tutorials
+        test -e ${{runner.workspace}}/tutorials
+
+    - name: Test that docs can be built without errors
+      shell: bash
+      run: |
+        set -e
+        bash build_docs.sh -v 0.0.1
+        test -e build/index.html
+
+    - name: Test that docs contain no broken links
+      shell: bash
+      run: |
+        set -e
+        bash build_docs.sh -v 0.0.1 -l

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
       run: |
         set -e
         python3 .github/package.py ${{runner.workspace}}/tutorials
-        test -e ${{runner.workspace}}/tutorials
+        test -e ${{runner.workspace}}/tutorials.zip
 
     - name: Test that docs can be built without errors
       shell: bash


### PR DESCRIPTION
Makes sure that the docs can be built with sphinx. Also tests that the packaging script works and produces a zip with all the tutorials.
Finally, checks that all links are valid.
This ensures that there is nothing that would break building of the documentation, so it can be safely auto-deployed
by the readthedocs script.

Can check the results by clicking on the Test/build action details.