### PR TITLE
Fix some broken links

### DIFF
--- a/doc/advanced/animations/README.md
+++ b/doc/advanced/animations/README.md
@@ -25,7 +25,7 @@ compression.
 ## Creating a simple animation with Blender
 
 In this tutorial, we use the excellent glTF exporter of Blender 2.83 LTS. You can just use [the existing scene
-in the Blender subfolder](https://github.com/bmwcarit/ramses-composer-docs/tree/master/advanced/animations/blender)
+in the Blender subfolder](https://github.com/bmwcarit/ramses-composer-docs/tree/master/doc/advanced/animations/blender)
 or create it yourself by following the steps below.
 
 * Select the default blender cube in a new project

--- a/doc/advanced/complex_import/README.md
+++ b/doc/advanced/complex_import/README.md
@@ -51,7 +51,7 @@ Composer to customize the import of data.
 ## Scene graph and resources
 
 This example project contains a complex scene consisting of multiple meshes and nodes. You can inspect
-the [Blender scene we used ](https://github.com/bmwcarit/ramses-composer-docs/tree/master/advanced/complex_import/blender). It contains a bunch of
+the [Blender scene we used ](https://github.com/bmwcarit/ramses-composer-docs/tree/master/doc/advanced/complex_import/blender). It contains a bunch of
 named shapes with a different position, orientation and scaling:
 
 ![](./docs/blender.png)
@@ -109,13 +109,13 @@ The import function puts all imported nodes inside a new root node with name equ
 ![](./docs/after_import.png)
 
 You can observe that the Composer imported the nodes exactly as they were
-defined in the [Blender scene](https://github.com/bmwcarit/ramses-composer-docs/tree/master/advanced/complex_import/blender)
+defined in the [Blender scene](https://github.com/bmwcarit/ramses-composer-docs/tree/master/doc/advanced/complex_import/blender)
 and kept their names and parental information. If you un-selected the `+Y is up` option in
 Blender glTF export menu, then the node properties (rotation, translation, scaling) are also exactly the same as in Blender. You can
 read up more on the subject in the section in the [Conventions chapter](../../basics/conventions/README.md).
 
 Next, we will modify some of the export/import settings. But first, let's make all meshes translucent by assigning a translucent
-material with a different color per mesh, and setting the blending to additive. We use simple [shaders](https://github.com/bmwcarit/ramses-composer-docs/tree/master/advanced/complex_import/shaders) which
+material with a different color per mesh, and setting the blending to additive. We use simple [shaders](https://github.com/bmwcarit/ramses-composer-docs/tree/master/doc/advanced/complex_import/shaders) which
 just assign a 4-component color, set alpha values lower than 1.0, and disable the depth buffer:
 
 ![](./docs/translucent_material_settings.png)

--- a/doc/advanced/traceplayer/README.md
+++ b/doc/advanced/traceplayer/README.md
@@ -103,7 +103,7 @@ The TracePlayer offers the following property in the **TracePlayerData** object:
 ## Example (BMW X5)
 
 This article includes a sample trace file based on the BMW X5 demo model. You can find it in the
-[traces folder](https://github.com/bmwcarit/ramses-composer-docs/tree/master/advanced/traceplayer/traces).
+[traces folder](https://github.com/bmwcarit/ramses-composer-docs/tree/master/doc/advanced/traceplayer/traces).
 
 Download the X5 project from its [repository](https://github.com/bmwcarit/digital-car-3d) and load the **G05_main.rca** file as documented in project README.
-Load and play the RaCo trace [g05_demo](https://github.com/bmwcarit/ramses-composer-docs/tree/master/advanced/traceplayer/traces/g05_demo.rctrace). Try changing the frame timestamps and properties to see how the playback changes in the Ramses Composer viewport.
+Load and play the RaCo trace [g05_demo](https://github.com/bmwcarit/ramses-composer-docs/tree/master/doc/advanced/traceplayer/traces/g05_demo.rctrace). Try changing the frame timestamps and properties to see how the playback changes in the Ramses Composer viewport.

--- a/doc/basics/android_app/README.md
+++ b/doc/basics/android_app/README.md
@@ -20,7 +20,7 @@ tutorial, we assume you have basic understanding of Android and will focus only 
 specifics.
 
 If you prefer looking at the final source code instead of going through the tutorial,
-you can find it in the [app_src](https://github.com/bmwcarit/ramses-composer-docs/tree/master/basics/android_app/app_src)
+you can find it in the [app_src](https://github.com/bmwcarit/ramses-composer-docs/tree/master/doc/basics/android_app/app_src)
 folder. Note that the sample source code
 was created with a fairly new Android Studio and may fail to open in older versions
 of the IDE.

--- a/doc/basics/monkey/README.md
+++ b/doc/basics/monkey/README.md
@@ -55,7 +55,7 @@ Note that the material has a few properties (uniforms in OpenGL terms) in its Pr
 ![](./docs/monkey_material.png)
 
 These uniforms are dynamically parsed out of the imported glSL shader (see the
-[fragment shader](https://github.com/bmwcarit/ramses-composer-docs/blob/master/basics/monkey/shaders/phong.frag#L8)).
+[fragment shader](https://github.com/bmwcarit/ramses-composer-docs/blob/master/doc/basics/monkey/shaders/phong.frag#L8)).
 You can edit the shader in your editor of choice, and as soon as the file is saved, the Composer will
 reload its uniforms (or display syntax errors when there are such).
 

--- a/doc/basics/offscreen/README.md
+++ b/doc/basics/offscreen/README.md
@@ -93,7 +93,7 @@ to its texture slots:
 ![](./docs/mapped_buffers.png)
 
 The material can therefore read the data from the buffers. If you look at the
-[fragment shader](https://github.com/bmwcarit/ramses-composer-docs/blob/master/basics/offscreen/shaders/resolve.frag#L13)
+[fragment shader](https://github.com/bmwcarit/ramses-composer-docs/blob/master/doc/basics/offscreen/shaders/resolve.frag#L13)
 you will notice
 that it displays half of the color buffer and half of the depth buffer (with enhanced contrast) based on
 texture coordinates. This produces the final image which shows a flat texture with the monkey head, with the


### PR DESCRIPTION
They broke after we restructured the docs, fixing them before we publish the new docs.