### PR TITLE
Fixes broken composer logo on read the docs

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -29,6 +29,7 @@ extensions = [
     "sphinx_rtd_theme",             # Read-the-docs html theme
     "sphinx.ext.autosectionlabel",  # Creates labels to sections in documents for easier :ref:-ing
     "myst_parser",                  # Can parse MyST markdown dialect
+    "sphinx_lfs_content",           # Ensures git lfs support on readthedocs
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -9,4 +9,4 @@
 myst-parser==0.18.1
 Sphinx==5.3.0
 sphinx-rtd-theme==1.0.0
-
+sphinx_lfs_content==1.1.1


### PR DESCRIPTION
ReadTheDocs doesn't support git lfs out of the box and needs an extension to properly fetch it on the published version of the docs.

More info: https://pypi.org/project/sphinx-lfs-content/