### PR TITLE
Fix paths in prefabs tutorial and remove unused images

### DIFF
--- a/doc/basics/prefabs/mesh/Lantern.gltf
+++ b/doc/basics/prefabs/mesh/Lantern.gltf
@@ -212,22 +212,10 @@
   ],
   "images": [
     {
-      "uri": "Lantern_baseColor.png"
+      "uri": "../texture/Lantern_baseColor.png"
     },
     {
-      "uri": "Lantern_roughnessMetallic.png"
-    },
-    {
-      "uri": "Lantern_normal.png"
-    },
-    {
-      "uri": "Lantern_emissive.png"
-    },
-    {
-      "uri": "Lantern_diffuse.png"
-    },
-    {
-      "uri": "Lantern_specularGlossiness.png"
+      "uri": "../texture/Lantern_emissive.png"
     }
   ],
   "meshes": [

--- a/doc/basics/prefabs/texture/Lantern_diffuse.png
+++ b/doc/basics/prefabs/texture/Lantern_diffuse.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1be68a584111630b518f29f0fc3b70501ed162d11a36f0145443be0051bc8461
-size 4024631

--- a/doc/basics/prefabs/texture/Lantern_normal.png
+++ b/doc/basics/prefabs/texture/Lantern_normal.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6a55a010e0d5b183b818c50a5cbb24fa61167228a530ab53d20cf0c2106a638c
-size 2928441

--- a/doc/basics/prefabs/texture/Lantern_roughnessMetallic.png
+++ b/doc/basics/prefabs/texture/Lantern_roughnessMetallic.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:01b8105756fd86f13e66602f85ee03e7e5daf22a8531f32bef8bbe678cf38cf6
-size 2078597

--- a/doc/basics/prefabs/texture/Lantern_specularGlossiness.png
+++ b/doc/basics/prefabs/texture/Lantern_specularGlossiness.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:dae27daeba3aa7d448f2ea55e541818fe007e5d54fdbec25cb0dc2d402b9b868
-size 2671827


### PR DESCRIPTION
Paths to texture resources in glTF file were broken and raco headless reports error. Fixed the paths.

Some of the images are not used, we can save up 10 MB of LFS memory - so removed them.

Newer RaCo checks image paths, even if the images
are not really used, and reports errors. This is
just workaround, probably should also fix the
raco error messages for such issues.