### PR TITLE
Update example github links to example-specific folders

### DIFF
--- a/doc/basics/blitpass/README.md
+++ b/doc/basics/blitpass/README.md
@@ -9,7 +9,7 @@ If a copy of the MPL was not distributed with this file, You can obtain one at h
 -->
 
 # BlitPass example
-*You can find the example project [here](https://github.com/bmwcarit/ramses-composer-docs/tree/master/doc/basics).*
+*You can find the example project [here](https://github.com/bmwcarit/ramses-composer-docs/tree/master/doc/basics/blitpass).*
 
 ![](./docs/blit_result_scene.png)
 

--- a/doc/basics/multisampling/README.md
+++ b/doc/basics/multisampling/README.md
@@ -9,7 +9,7 @@ If a copy of the MPL was not distributed with this file, You can obtain one at h
 -->
 
 # Multisampling example
-*You can find the example project [here](https://github.com/bmwcarit/ramses-composer-docs/tree/master/doc/basics).*
+*You can find the example project [here](https://github.com/bmwcarit/ramses-composer-docs/tree/master/doc/basics/multisampling).*
 
 ![](./docs/msaa_result_scene.png)
 


### PR DESCRIPTION
Follow-up for https://github.com/bmwcarit/ramses-composer-docs/pull/59: linkcheck prevented us from using links to example-specific folders:
https://github.com/bmwcarit/ramses-composer-docs/tree/master/doc/basics/blitpass
https://github.com/bmwcarit/ramses-composer-docs/tree/master/doc/basics/multisampling

Now as #59 is merged, we can update these links.